### PR TITLE
Determine latest stable version of acme.sh in docker_build.yaml

### DIFF
--- a/.github/workflows/docker_build.yaml
+++ b/.github/workflows/docker_build.yaml
@@ -33,7 +33,6 @@ env:
   latest_base_os: ubuntu
   stable_base_os: ubuntu
   latest_acmesh_version: master
-  stable_acmesh_version: 2.9.0
   latest_branch: main
   stable_branch_prefix: stable/
 
@@ -127,6 +126,8 @@ jobs:
       - name: Checkout Code
         id: checkout_code
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
@@ -143,7 +144,6 @@ jobs:
           DATE_STAMP: ${{ needs.prepare.outputs.date_stamp }}
           PLATFORM: ${{ matrix.platform }}
           LATEST_ACMESH_VERSION: ${{ env.latest_acmesh_version }}
-          STABLE_ACMESH_VERSION: ${{ env.stable_acmesh_version }}
           LATEST_BRANCH: ${{ env.latest_branch }}
           STABLE_BRANCH_PREFIX: ${{ env.stable_branch_prefix }}
         run: .github/workflows/scripts/get_parameters.sh
@@ -254,7 +254,7 @@ jobs:
         run: .github/workflows/scripts/docker_manifest.py dated_os
         env:
           LATEST_ACMESH_VERSION: ${{ env.latest_acmesh_version }}
-          STABLE_ACMESH_VERSION: ${{ env.stable_acmesh_version }}
+          STABLE_ACMESH_VERSION: ${{ steps.get_parameters.outputs.acmesh_latest_stable_version}}
           LATEST_BRANCH: ${{ env.latest_branch }}
           STABLE_BRANCH_PREFIX: ${{ env.stable_branch_prefix }}
           LATEST_BASE_OS: ${{ env.latest_base_os }}
@@ -287,7 +287,7 @@ jobs:
         run: .github/workflows/scripts/docker_manifest.py dynamic_os
         env:
           LATEST_ACMESH_VERSION: ${{ env.latest_acmesh_version }}
-          STABLE_ACMESH_VERSION: ${{ env.stable_acmesh_version }}
+          STABLE_ACMESH_VERSION: ${{ steps.get_parameters.outputs.acmesh_latest_stable_version}}
           LATEST_BRANCH: ${{ env.latest_branch }}
           STABLE_BRANCH_PREFIX: ${{ env.stable_branch_prefix }}
           LATEST_BASE_OS: ${{ env.latest_base_os }}
@@ -320,7 +320,7 @@ jobs:
         run: .github/workflows/scripts/docker_manifest.py dynamic
         env:
           LATEST_ACMESH_VERSION: ${{ env.latest_acmesh_version }}
-          STABLE_ACMESH_VERSION: ${{ env.stable_acmesh_version }}
+          STABLE_ACMESH_VERSION: ${{ steps.get_parameters.outputs.acmesh_latest_stable_version}}
           LATEST_BRANCH: ${{ env.latest_branch }}
           STABLE_BRANCH_PREFIX: ${{ env.stable_branch_prefix }}
           LATEST_BASE_OS: ${{ env.latest_base_os }}
@@ -353,7 +353,7 @@ jobs:
         run: .github/workflows/scripts/docker_manifest.py acmesh_versioned
         env:
           LATEST_ACMESH_VERSION: ${{ env.latest_acmesh_version }}
-          STABLE_ACMESH_VERSION: ${{ env.stable_acmesh_version }}
+          STABLE_ACMESH_VERSION: ${{ steps.get_parameters.outputs.acmesh_latest_stable_version}}
           LATEST_BRANCH: ${{ env.latest_branch }}
           STABLE_BRANCH_PREFIX: ${{ env.stable_branch_prefix }}
           LATEST_BASE_OS: ${{ env.latest_base_os }}

--- a/.github/workflows/scripts/get_parameters.sh
+++ b/.github/workflows/scripts/get_parameters.sh
@@ -1,46 +1,63 @@
 #!/bin/bash -eu
 # get_parameters.sh determines what acme.sh version to build and the docker image tags.
 #
-# This script sets two variables, 'acmesh_version' and `tag` used by downstream jobs.
+# This script sets two variables, 'acmesh_version', 'tag' and 'acmesh_stable_version'
+# used by downstream jobs.
 
-echo "** Will determine acme.sh version and Docker tags"
+acmesh_latest_stable_version() {
+    STABLE_ACMESH_VERSION=$(git branch --all | grep "remotes/origin/stable/" | cut --fields=4 --delimiter="/" | sort | tail --lines 1)
 
-STABLE_BRANCH_PREFIX_ESCAPED=$(sed 's/[^^]/[&]/g; s/\^/\\^/g' <<<"$STABLE_BRANCH_PREFIX")
-
-if [[ "$GITHUB_REF" == refs/heads/$LATEST_BRANCH ]]; then
-    # acme.sh uses master branch names, but we use main. While getting the artifacts
-    # from acme.sh we use master.
-    ACMESH_VERSION="$LATEST_ACMESH_VERSION"
-    # Tag Format: <base_os>-<acmesh-version>-<date-stamp>-<platform>
-    DOCKER_IMAGE_TAG="${BASE_IMAGE}-${ACMESH_VERSION}-${DATE_STAMP}-$(echo "${PLATFORM}" | tr '/' '_')-${GITHUB_RUN_ID}"
-elif [[ "$GITHUB_REF" =~ refs\/heads\/$STABLE_BRANCH_PREFIX_ESCAPED ]]; then
-    ACMESH_VERSION="${GITHUB_REF#refs/heads/$STABLE_BRANCH_PREFIX_ESCAPED}"
-    # Tag Format: <base_os>-<acmesh-version>-<date-stamp>-<platform>
-    DOCKER_IMAGE_TAG="${BASE_IMAGE}-${ACMESH_VERSION}-${DATE_STAMP}-$(echo "${PLATFORM}" | tr '/' '-')-${GITHUB_RUN_ID}"
-elif [[ "$GITHUB_REF" =~ refs\/tags\/v.+ ]]; then
-    # acme.sh doesn't tag with a prefix v, but this repo does. So we drop the v when
-    # getting the artifacts from acme.sh and also tag without the v in docker images
-    ACMESH_VERSION="${GITHUB_REF#refs/tags/v}"
-    DOCKER_IMAGE_TAG="${BASE_IMAGE}-${ACMESH_VERSION}-${DATE_STAMP}-$(echo "${PLATFORM}" | tr '/' '-')-${GITHUB_RUN_ID}"
-elif [[ $GITHUB_EVENT_NAME == "pull_request" ]]; then
-    PULL_REQUEST_NUMBER=$(echo "$GITHUB_REF" | cut -f3 -d"/")
-
-    if [[ $GITHUB_BASE_REF == "$LATEST_BRANCH" ]]; then
-        echo "** Pull Request is based on latest branch $GITHUB_BASE_REF will use $LATEST_ACMESH_VERSION"
-        ACMESH_VERSION="$LATEST_ACMESH_VERSION"
-    elif [[ $GITHUB_BASE_REF == "$STABLE_BRANCH" ]]; then
-        echo "** Pull Request is based on stable branch $GITHUB_BASE_REF will use $STABLE_ACMESH_VERSION"
-        ACMESH_VERSION="$STABLE_ACMESH_VERSION"
-    else
-        echo "** Pull Request is based on $GITHUB_BASE_REF branch and no rule for acme version set, will use $LATEST_ACMESH_VERSION"
-        ACMESH_VERSION="${GITHUB_BASE_REF}"
+    if [ -z "$STABLE_ACMESH_VERSION" ]; then
+        echo "** Unable to determine STABLE_ACMESH_VERSION from git branch --all"
+        git branch --all
+        exit 1
     fi
-    # Tag Format: <base_os>-<acmesh-version>-<date-stamp>-<platform>-pr<pr_number>
-    DOCKER_IMAGE_TAG="${BASE_IMAGE}-${ACMESH_VERSION}-${DATE_STAMP}-$(echo "${PLATFORM}" | tr '/' '_')-pr${PULL_REQUEST_NUMBER}s"
-else
-    echo "** No rule defined for this build in order to get parameters."
-    exit 1
-fi
+}
 
-echo ::set-output name=tag::"$DOCKER_IMAGE_TAG"
-echo ::set-output name=acmesh_version::"$ACMESH_VERSION"
+get_parameters() {
+    echo "** Will determine acme.sh version and Docker tags"
+
+    STABLE_BRANCH_PREFIX_ESCAPED=$(sed 's/[^^]/[&]/g; s/\^/\\^/g' <<<"$STABLE_BRANCH_PREFIX")
+
+    if [[ "$GITHUB_REF" == refs/heads/$LATEST_BRANCH ]]; then
+        # acme.sh uses master branch names, but we use main. While getting the artifacts
+        # from acme.sh we use master.
+        ACMESH_VERSION="$LATEST_ACMESH_VERSION"
+        # Tag Format: <base_os>-<acmesh-version>-<date-stamp>-<platform>
+        DOCKER_IMAGE_TAG="${BASE_IMAGE}-${ACMESH_VERSION}-${DATE_STAMP}-$(echo "${PLATFORM}" | tr '/' '_')-${GITHUB_RUN_ID}"
+    elif [[ "$GITHUB_REF" =~ refs\/heads\/$STABLE_BRANCH_PREFIX_ESCAPED ]]; then
+        ACMESH_VERSION="${GITHUB_REF#refs/heads/$STABLE_BRANCH_PREFIX_ESCAPED}"
+        # Tag Format: <base_os>-<acmesh-version>-<date-stamp>-<platform>
+        DOCKER_IMAGE_TAG="${BASE_IMAGE}-${ACMESH_VERSION}-${DATE_STAMP}-$(echo "${PLATFORM}" | tr '/' '-')-${GITHUB_RUN_ID}"
+    elif [[ "$GITHUB_REF" =~ refs\/tags\/v.+ ]]; then
+        # acme.sh doesn't tag with a prefix v, but this repo does. So we drop the v when
+        # getting the artifacts from acme.sh and also tag without the v in docker images
+        ACMESH_VERSION="${GITHUB_REF#refs/tags/v}"
+        DOCKER_IMAGE_TAG="${BASE_IMAGE}-${ACMESH_VERSION}-${DATE_STAMP}-$(echo "${PLATFORM}" | tr '/' '-')-${GITHUB_RUN_ID}"
+    elif [[ $GITHUB_EVENT_NAME == "pull_request" ]]; then
+        PULL_REQUEST_NUMBER=$(echo "$GITHUB_REF" | cut -f3 -d"/")
+
+        if [[ $GITHUB_BASE_REF == "$LATEST_BRANCH" ]]; then
+            echo "** Pull Request is based on latest branch $GITHUB_BASE_REF will use $LATEST_ACMESH_VERSION"
+            ACMESH_VERSION="$LATEST_ACMESH_VERSION"
+        elif [[ $GITHUB_BASE_REF == "$STABLE_BRANCH" ]]; then
+            echo "** Pull Request is based on stable branch $GITHUB_BASE_REF will use $STABLE_ACMESH_VERSION"
+            ACMESH_VERSION="$STABLE_ACMESH_VERSION"
+        else
+            echo "** Pull Request is based on $GITHUB_BASE_REF branch and no rule for acme version set, will use $LATEST_ACMESH_VERSION"
+            ACMESH_VERSION="${GITHUB_BASE_REF}"
+        fi
+        # Tag Format: <base_os>-<acmesh-version>-<date-stamp>-<platform>-pr<pr_number>
+        DOCKER_IMAGE_TAG="${BASE_IMAGE}-${ACMESH_VERSION}-${DATE_STAMP}-$(echo "${PLATFORM}" | tr '/' '_')-pr${PULL_REQUEST_NUMBER}s"
+    else
+        echo "** No rule defined for this build in order to get parameters."
+        exit 1
+    fi
+
+    echo ::set-output name=tag::"$DOCKER_IMAGE_TAG"
+    echo ::set-output name=acmesh_version::"$ACMESH_VERSION"
+    echo ::set-output name=acmesh_stable_version::"$STABLE_ACMESH_VERSION"
+}
+
+acmesh_latest_stable_version
+get_parameters


### PR DESCRIPTION
* The workflow had the value of latest stable acme.sh hardcoded.
* The value can be determined using the branches and sorting them.
* Updating workflow to use a determined value instead of the one hardcoded.