### PR TITLE
Adding check for existing user before creating

### DIFF
--- a/alpinelinux/root/etc/cont-init.d/01-adduser.sh
+++ b/alpinelinux/root/etc/cont-init.d/01-adduser.sh
@@ -8,8 +8,12 @@ if [[ $EUID -ne 0 ]]; then
 fi
 
 if [[ $PUID != 0 ]]; then
-    adduser -HD -h "$LE_CONFIG_HOME" -s /bin/false --uid "$PUID" container
-    echo "** Added user 'container' with UID: '$PUID'"
+    if id -u container &>/dev/null; then
+        echo "** User 'container' already exists"
+    else
+        adduser -HD -h "$LE_CONFIG_HOME" -s /bin/false --uid "$PUID" container
+        echo "** Added user 'container' with UID: '$PUID'"
+    fi
 
     if [[ $PGID != 0 && $PGID != "$PUID" ]]; then
         addgroup -g "$PGID" container_group

--- a/amazonlinux/root/etc/cont-init.d/01-adduser.sh
+++ b/amazonlinux/root/etc/cont-init.d/01-adduser.sh
@@ -8,8 +8,12 @@ if [[ $EUID -ne 0 ]]; then
 fi
 
 if [[ $PUID != 0 ]]; then
-    adduser --no-create-home --home "$LE_CONFIG_HOME" --shell /bin/false --uid "$PUID" container
-    echo "** Added user 'container' with UID: '$PUID'"
+    if id -u container &>/dev/null; then
+        echo "** User 'container' already exists"
+    else
+        adduser --no-create-home --home "$LE_CONFIG_HOME" --shell /bin/false --uid "$PUID" container
+        echo "** Added user 'container' with UID: '$PUID'"
+    fi
 
     if [[ $PGID != 0 && $PGID != "$PUID" ]]; then
         groupadd --gid "$PGID" container_group

--- a/rockylinux/root/etc/cont-init.d/01-adduser.sh
+++ b/rockylinux/root/etc/cont-init.d/01-adduser.sh
@@ -8,8 +8,12 @@ if [[ $EUID -ne 0 ]]; then
 fi
 
 if [[ $PUID != 0 ]]; then
-    adduser --no-create-home --home "$LE_CONFIG_HOME" --shell /bin/false --uid "$PUID" container
-    echo "** Added user 'container' with UID: '$PUID'"
+    if id -u container &>/dev/null; then
+        echo "** User 'container' already exists"
+    else
+        adduser --no-create-home --home "$LE_CONFIG_HOME" --shell /bin/false --uid "$PUID" container
+        echo "** Added user 'container' with UID: '$PUID'"
+    fi
 
     if [[ $PGID != 0 && $PGID != "$PUID" ]]; then
         groupadd --gid "$PGID" container_group

--- a/ubuntu/root/etc/cont-init.d/01-adduser.sh
+++ b/ubuntu/root/etc/cont-init.d/01-adduser.sh
@@ -8,8 +8,12 @@ if [[ $EUID -ne 0 ]]; then
 fi
 
 if [[ $PUID != 0 ]]; then
-    adduser --no-create-home --disabled-password --disabled-login --home "$LE_CONFIG_HOME" --gecos "" --shell /bin/false --uid "$PUID" container
-    echo "** Added user 'container' with UID: '$PUID'"
+    if id -u container &>/dev/null; then
+        echo "** User 'container' already exists"
+    else
+        adduser --no-create-home --disabled-password --disabled-login --home "$LE_CONFIG_HOME" --gecos "" --shell /bin/false --uid "$PUID" container
+        echo "** Added user 'container' with UID: '$PUID'"
+    fi
 
     if [[ $PGID != 0 && $PGID != "$PUID" ]]; then
         addgroup --gid "$PGID" container_group


### PR DESCRIPTION
* When restarting a renewal deamon, the container fails
  because the user already exists.
* Adding a check to the start up process to see if user
  already exists and if so, skip.
  
  https://github.com/digimach/docker-acme.sh/issues/24